### PR TITLE
Bump version, add OS support, bugfixes and more

### DIFF
--- a/github-runner/defaults.yaml
+++ b/github-runner/defaults.yaml
@@ -3,4 +3,3 @@ github-runner:
   base_url: 'https://github.com/actions/runner/releases/download'
   script_suffix: 'sh'
   package_url: ''
-  package_suffix: 'tar.gz'

--- a/github-runner/defaults.yaml
+++ b/github-runner/defaults.yaml
@@ -1,5 +1,5 @@
 github-runner:
-  version: '2.284.0'
+  version: '2.321.0'
   base_url: 'https://github.com/actions/runner/releases/download'
   script_suffix: 'sh'
   package_url: ''

--- a/github-runner/defaults.yaml
+++ b/github-runner/defaults.yaml
@@ -1,5 +1,6 @@
 github-runner:
   version: '2.321.0'
+  package_hash: "ba46ba7ce3a4d7236b16fbe44419fb453bc08f866b24f04d549ec89f1722a29e"
   base_url: 'https://github.com/actions/runner/releases/download'
   script_suffix: 'sh'
   package_url: ''

--- a/github-runner/defaults.yaml
+++ b/github-runner/defaults.yaml
@@ -1,6 +1,5 @@
 github-runner:
   version: '2.321.0'
-  package_hash: "ba46ba7ce3a4d7236b16fbe44419fb453bc08f866b24f04d549ec89f1722a29e"
   base_url: 'https://github.com/actions/runner/releases/download'
   script_suffix: 'sh'
   package_url: ''

--- a/github-runner/init.sls
+++ b/github-runner/init.sls
@@ -60,7 +60,7 @@ Create ghrunner user:
     - name: >-
         {{ github_runner_settings.install_dir }}/svc.{{
           github_runner_settings.script_suffix
-        }} install
+        }} install ghrunner
     - creates: {{ github_runner_settings.install_dir }}/.service
     - require:
       - cmd: "GitHub Runner Software"

--- a/github-runner/init.sls
+++ b/github-runner/init.sls
@@ -46,10 +46,12 @@ Create ghrunner user:
     - cwd: {{ github_runner_settings.install_dir }}
     - require:
       - archive: "GitHub Runner Software"
-    - creates: >-
-        {{ github_runner_settings.install_dir }}/svc.{{
-          github_runner_settings.script_suffix
-        }}
+    - creates:
+        - {{ github_runner_settings.install_dir }}/.credentials
+        - {{ github_runner_settings.install_dir }}/.runner
+        - {{ github_runner_settings.install_dir }}/svc.{{
+            github_runner_settings.script_suffix
+          }}
 
 # We use cmd instead of file built-in state because that only supports
 # octal encoding (issue #32681).
@@ -93,5 +95,4 @@ Create ghrunner user:
         systemctl start $SERVICE
     - require:
       - cmd: "GitHub Runner Service"
-    - onlyif: test -f {{ github_runner_settings.install_dir }}/.service
 {%- endif %}

--- a/github-runner/init.sls
+++ b/github-runner/init.sls
@@ -41,6 +41,7 @@ Create ghrunner user:
         }}
         --unattended --url {{ github_runner_settings.repo_url }}
         --token {{ github_runner_settings.repo_token }}
+        --lables {{ ','.join(github_runner_settings.labels) }}
     - runas: ghrunner
     - cwd: {{ github_runner_settings.install_dir }}
     - require:

--- a/github-runner/init.sls
+++ b/github-runner/init.sls
@@ -11,10 +11,18 @@
     - require:
       - file: "GitHub Runner Software"
   cmd.run:
-    - name: {{ github_runner_settings.install_dir }}/config.{{ github_runner_settings.script_suffix }} --unattended --url {{ github_runner_settings.repo_url }} --token ${{ github_runner_settings.repo_token }}
+    - name: >-
+        {{ github_runner_settings.install_dir }}/config.{{
+          github_runner_settings.script_suffix
+        }}
+        --unattended --url {{ github_runner_settings.repo_url }}
+        --token ${{ github_runner_settings.repo_token }}
     - require:
       - archive: "GitHub Runner Software"
-    - creates: {{ github_runner_settings.install_dir }}/svc.{{ github_runner_settings.script_suffix }}
+    - creates: >-
+        {{ github_runner_settings.install_dir }}/svc.{{
+          github_runner_settings.script_suffix
+        }}
 
 "GitHub Runner Service":
   service.runner:
@@ -24,8 +32,14 @@
       - archive: "GitHub Runner Software"
       - cmd: "GitHub Runner Service"
   cmd.run:
-    - name: {{ github_runner_settings.install_dir}}/svc.{{ github_runner_settings.script_suffix }} install
+    - name: >-
+        {{ github_runner_settings.install_dir}}/svc.{{
+          github_runner_settings.script_suffix
+        }} install
     - require:
-      - file: {{ github_runner_settings.install_dir }}/svc.{{ github_runner_settings.script_suffix }}
+      - file: >-
+          {{ github_runner_settings.install_dir }}/svc.{{
+            github_runner_settings.script_suffix
+          }}
     - watch:
       - cmd: "GitHub Runner Software"

--- a/github-runner/init.sls
+++ b/github-runner/init.sls
@@ -7,7 +7,9 @@
   archive.extracted:
     - name: {{ github_runner_settings.install_dir }}
     - source: {{ github_runner_settings.package_url }}
+{%- if github_runner_settings.package_hash %}
     - source_hash: sha256={{ github_runner_settings.package_hash }}
+{%- endif %}
     - require:
       - file: "GitHub Runner Software"
   cmd.run:

--- a/github-runner/init.sls
+++ b/github-runner/init.sls
@@ -27,21 +27,20 @@
         }}
 
 "GitHub Runner Service":
-  service.runner:
-    - name: {{ github_runner_settings.service_name }}
-    - enable: true
-    - require:
-      - archive: "GitHub Runner Software"
-      - cmd: "GitHub Runner Service"
   cmd.run:
     - name: >-
-        {{ github_runner_settings.install_dir}}/svc.{{
+        {{ github_runner_settings.install_dir }}/svc.{{
           github_runner_settings.script_suffix
         }} install
+    - creates: {{ github_runner_settings.install_dir }}/.service
     - require:
-      - file: >-
-          {{ github_runner_settings.install_dir }}/svc.{{
-            github_runner_settings.script_suffix
-          }}
-    - watch:
       - cmd: "GitHub Runner Software"
+  service.runner:
+    - name: {{
+        salt['cmd.run'](
+          "cat '" ~ github_runner_settings.install_dir ~ "/.service'"
+        )
+      }}
+    - enable: true
+    - require:
+      - cmd: "GitHub Runner Service"

--- a/github-runner/init.sls
+++ b/github-runner/init.sls
@@ -32,6 +32,7 @@ Create ghrunner user:
 {%- endif %}
     - user: ghrunner
     - group: ghrunner
+    - unless: test -f /opt/github/actions-runner/run.sh
     - require:
       - file: "GitHub Runner Software"
   cmd.run:

--- a/github-runner/init.sls
+++ b/github-runner/init.sls
@@ -42,7 +42,7 @@ Create ghrunner user:
         }}
         --unattended --url {{ github_runner_settings.repo_url }}
         --token {{ github_runner_settings.repo_token }}
-        --lables {{ ','.join(github_runner_settings.labels) }}
+        --labels {{ ','.join(github_runner_settings.labels) }}
 {%- if "runnergroup" in github_runner_settings %}
         --runnergroup {{ github_runner_settings.runnergroup }}
 {%- endif %}

--- a/github-runner/init.sls
+++ b/github-runner/init.sls
@@ -42,6 +42,9 @@ Create ghrunner user:
         --unattended --url {{ github_runner_settings.repo_url }}
         --token {{ github_runner_settings.repo_token }}
         --lables {{ ','.join(github_runner_settings.labels) }}
+{%- if "runnergroup" in github_runner_settings %}
+        --runnergroup {{ github_runner_settings.runnergroup }}
+{%- endif %}
     - runas: ghrunner
     - cwd: {{ github_runner_settings.install_dir }}
     - require:

--- a/github-runner/init.sls
+++ b/github-runner/init.sls
@@ -40,7 +40,7 @@ Create ghrunner user:
           github_runner_settings.script_suffix
         }}
         --unattended --url {{ github_runner_settings.repo_url }}
-        --token ${{ github_runner_settings.repo_token }}
+        --token {{ github_runner_settings.repo_token }}
     - runas: ghrunner
     - cwd: {{ github_runner_settings.install_dir }}
     - require:

--- a/github-runner/map.jinja
+++ b/github-runner/map.jinja
@@ -2,12 +2,12 @@
 # vim: ft=jinja
 {%- import_yaml 'github-runner/defaults.yaml as defaults %}
 
-{# merge os specific defaults over our defaults #}
-{% import_yaml 'github-runner/osmap.yaml' as osmap %}
-{% set osmap = salt['grains.filter_by'](osmap, grain='kernel') or {} %}
-{% do salt['defaults.merge'](defaults['github-runner'], osmap) %}
+{#- Merge os specific defaults over our defaults #}
+{%- import_yaml 'github-runner/osmap.yaml' as osmap %}
+{%- set osmap = salt['grains.filter_by'](osmap, grain='kernel') or {} %}
+{%- do salt['defaults.merge'](defaults['github-runner'], osmap) %}
 
-{# Allow custom imports to reduce pillar load on the master #}
+{#- Allow custom imports to reduce pillar load on the master #}
 {%- set import_file = salt['pillar.get']('github-runner:defaults', '') %}
 {%- if import_file != '' %}
   {%- set custom_defaults = {} %}

--- a/github-runner/map.jinja
+++ b/github-runner/map.jinja
@@ -4,8 +4,7 @@
 {%- import_yaml "github-runner/defaults.yaml" as defaults %}
 
 {#- Merge os specific defaults over our defaults #}
-{%- import_yaml 'github-runner/osmap.yaml' as osmap %}
-{%- set osmap = salt['grains.filter_by'](osmap, grain='kernel') or {} %}
+{%- from "github-runner/osmap.jinja" import osmap with context %}
 {%- do salt['defaults.merge'](defaults['github-runner'], osmap) %}
 
 {#- Allow custom imports to reduce pillar load on the master #}
@@ -40,7 +39,8 @@
 %}
 
 {%- if github_runner_settings.package_url|length == 0 %}
-  {%- set arch = salt['grains.get']('osarch', grains['cpuarch'])|lower %}
+  {%- set cpuarch_grain = salt['grains.get']('osarch', grains['cpuarch']) %}
+  {%- set arch = cpuarch_grain|lower %}
   {%- if arch in ("amd64", "x86_64") %}
   {%- set arch = "x64" %}
   {%- elif arch == "aarch64" %}
@@ -49,7 +49,8 @@
   {%- set arch = "arm" %}
   {%- endif %}
 
-  {%- set kernel = salt['grains.get']('kernel')|lower %}
+  {%- set kernel_grain = salt['grains.get']('kernel') %}
+  {%- set kernel = kernel_grain|lower %}
   {%- set package_suffix = "tar.gz" %}
   {%- if kernel == "MacOS" %}
   {%- set kernel = "osx" %}
@@ -57,17 +58,14 @@
   {%- set kernel = "win" %}
   {%- set package_suffix = "zip" %}
   {%- endif %}
-
-  {%- set version = github_runner_settings.version %}
+  {%- do github_runner_settings.update({'kernel': kernel }) %}
 
   {%-
-    set download_loc = '{{ github_runner_settings.base_url }}/v{{ version }}'
+    set package_hash = github_runner_settings.get('package_hashes', {}).get(
+      arch
+    )
   %}
-  {%-
-    set package_name = 'actions-runner-{{ kernel }}{{ arch }}-{{ version }}.{{
-      package_suffix
-    }}'
-  %}
+  {%- do github_runner_settings.update({'package_hash': package_hash }) %}
 
   {%- if "labels" not in github_runner_settings %}
   {%- do github_runner_settings.update({'labels': []}) %}

--- a/github-runner/map.jinja
+++ b/github-runner/map.jinja
@@ -11,7 +11,9 @@
 {%- set import_file = salt['pillar.get']('github-runner:defaults', '') %}
 {%- if import_file != '' %}
   {%- set custom_defaults = {} %}
-  {%- set import_type = import_file|lower|regex_match('.*\.(json|ya?ml|jinja)$') %}
+  {%-
+    set import_type = import_file|lower|regex_match('.*\.(json|ya?ml|jinja)$')
+  %}
   {%- if import_type|length > 0 %}
     {%- if import_type[0] in ['json'] %}
       {%- import_json import_file as custom_defaults %}
@@ -24,15 +26,33 @@
   {%- do salt['defaults.merge'](defaults, custom_defaults) %}
 {%- endif %}
 
-{# While we try to encourage usage of custom defaults within the state tree, we
-   want to be flexible enough to support pillar overrides for any setting #}
-{%- set github_runner_settings = salt['pillar.get']('github-runner', defaults['github-runner'], merge=True) %}
+{#-
+ # While we try to encourage usage of custom defaults within the state
+ # tree, we want to be flexible enough to support pillar overrides for
+ # any setting
+#}
+{%-
+  set github_runner_settings = salt['pillar.get'](
+    'github-runner', defaults['github-runner'],
+    merge=True,
+  )
+%}
 
 {%- if github_runner_settings.package_url|length == 0 %}
   {%- set arch = salt['grains.get']('osarch', grains['cpuarch'])|lower %}
   {%- set kernel = salt['grains.get']('kernel')|lower %}
   {%- set version = github_runner_settings.version %}
-  {%- set package_suffix = github_runner_settings.package_suffix %}
-  {%- set package_url = '{{ github_runner_settings.base_url }}/v{{ version }}/actions-runner-{{ kernel }}{{ arch }}-{{ version }}.{{ package_suffix }}' %}
+
+  {%-
+    set download_loc = '{{ github_runner_settings.base_url }}/v{{ version }}'
+  %}
+  {%-
+    set package_name = 'actions-runner-{{ kernel }}{{ arch }}-{{ version }}.{{
+      package_suffix
+    }}'
+  %}
+  {%-
+    set package_url = '{{ download_loc }}/{{ package_name }}'
+  %}
   {%- do github_runner_settings.update({'package_url': package_url }) %}
 {%- endif %}

--- a/github-runner/map.jinja
+++ b/github-runner/map.jinja
@@ -67,6 +67,12 @@
       package_suffix
     }}'
   %}
+
+  {%- if "labels" not in github_runner_settings %}
+  {%- do github_runner_settings.update({'labels': []}) %}
+  {%- endif %}
+  {%- do github_runner_settings.labels.append(cpuarch_grain) %}
+  {%- do github_runner_settings.labels.append(kernel_grain) %}
   {%-
     set package_url = '{{ download_loc }}/{{ package_name }}'
   %}

--- a/github-runner/map.jinja
+++ b/github-runner/map.jinja
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: ft=jinja
-{%- import_yaml 'github-runner/defaults.yaml as defaults %}
+
+{%- import_yaml "github-runner/defaults.yaml" as defaults %}
 
 {#- Merge os specific defaults over our defaults #}
 {%- import_yaml 'github-runner/osmap.yaml' as osmap %}

--- a/github-runner/map.jinja
+++ b/github-runner/map.jinja
@@ -72,8 +72,14 @@
   {%- endif %}
   {%- do github_runner_settings.labels.append(cpuarch_grain) %}
   {%- do github_runner_settings.labels.append(kernel_grain) %}
+
+  {%- set version = github_runner_settings.version %}
+
+  {%- set download_loc = github_runner_settings.base_url ~ '/v' ~ version %}
   {%-
-    set package_url = '{{ download_loc }}/{{ package_name }}'
+    set package_name = 'actions-runner-' ~ kernel ~ '-' ~ arch ~ '-' ~
+      version ~ '.' ~ package_suffix
   %}
+  {%- set package_url = download_loc ~ '/' ~ package_name %}
   {%- do github_runner_settings.update({'package_url': package_url }) %}
 {%- endif %}

--- a/github-runner/map.jinja
+++ b/github-runner/map.jinja
@@ -49,6 +49,14 @@
   {%- endif %}
 
   {%- set kernel = salt['grains.get']('kernel')|lower %}
+  {%- set package_suffix = "tar.gz" %}
+  {%- if kernel == "MacOS" %}
+  {%- set kernel = "osx" %}
+  {%- elif kernel == "Windows" %}
+  {%- set kernel = "win" %}
+  {%- set package_suffix = "zip" %}
+  {%- endif %}
+
   {%- set version = github_runner_settings.version %}
 
   {%-

--- a/github-runner/map.jinja
+++ b/github-runner/map.jinja
@@ -40,6 +40,14 @@
 
 {%- if github_runner_settings.package_url|length == 0 %}
   {%- set arch = salt['grains.get']('osarch', grains['cpuarch'])|lower %}
+  {%- if arch in ("amd64", "x86_64") %}
+  {%- set arch = "x64" %}
+  {%- elif arch == "aarch64" %}
+  {%- set arch = "arm64" %}
+  {%- elif arch in ("armhf", "armv7l")  %}
+  {%- set arch = "arm" %}
+  {%- endif %}
+
   {%- set kernel = salt['grains.get']('kernel')|lower %}
   {%- set version = github_runner_settings.version %}
 

--- a/github-runner/osmap.jinja
+++ b/github-runner/osmap.jinja
@@ -2,10 +2,14 @@
 # vim: ft=yaml
 ---
 
-Linux:
-  script_suffix: sh
+MacOS:
   install_dir: /opt/github/actions-runner
+  script_suffix: sh
+
+Linux:
+  install_dir: /opt/github/actions-runner
+  script_suffix: sh
 
 Windows:
-  script_suffix: cmd
   install_dir: 'C:/github/actions-runner'
+  script_suffix: cmd

--- a/github-runner/osmap.jinja
+++ b/github-runner/osmap.jinja
@@ -1,18 +1,35 @@
 # -*- coding: utf-8 -*-
-# vim: ft=yaml
----
+# vim: ft=jinja
 
-MacOS:
-  install_dir: /opt/github/actions-runner
-  package_hash: b2c91416b3e4d579ae69fc2c381fc50dbda13f1b3fcc283187e2c75d1b173072
-  script_suffix: sh
-
-Linux:
-  install_dir: /opt/github/actions-runner
-  package_hash: ba46ba7ce3a4d7236b16fbe44419fb453bc08f866b24f04d549ec89f1722a29e
-  script_suffix: sh
-
-Windows:
-  install_dir: 'C:/github/actions-runner'
-  package_hash: 88d754da46f4053aec9007d172020c1b75ab2e2049c08aef759b643316580bbc
-  script_suffix: cmd
+{%-
+  set osmap = salt['grains.filter_by'](
+    {
+      'MacOS': {
+        'install_dir': '/opt/github/actions-runner',
+        'package_hashes': {
+          'arm64': 'fbee07e42a134645d4f04f8146b0a3d0b3c948f0d6b2b9fa61f4318c1192ff79',
+          'x68': 'b2c91416b3e4d579ae69fc2c381fc50dbda13f1b3fcc283187e2c75d1b173072',
+         },
+        'script_suffix': 'sh',
+      },
+      'Linux': {
+        'install_dir': '/opt/github/actions-runner',
+        'package_hashes': {
+          'x64': 'ba46ba7ce3a4d7236b16fbe44419fb453bc08f866b24f04d549ec89f1722a29e',
+          'arm': '2b96a4991ebf2b2076908a527a1a13db590217f9375267b5dd95f0300dde432b',
+          'arm64': '62cc5735d63057d8d07441507c3d6974e90c1854bdb33e9c8b26c0da086336e1',
+        },
+        'script_suffix': 'sh',
+      },
+      'Windows': {
+        'install_dir': 'C:/github/actions-runner',
+        'package_hashes': {
+          'x64': '88d754da46f4053aec9007d172020c1b75ab2e2049c08aef759b643316580bbc',
+          'arm64': '22df5a32a65a55e43dab38a200d4f72be0f9f5ce1839f5ad34e689a0d3ff0fb7',
+        },
+        'script_suffix': 'cmd',
+      },
+    },
+    grain='kernel',
+  ) or {}
+%}

--- a/github-runner/osmap.jinja
+++ b/github-runner/osmap.jinja
@@ -4,12 +4,15 @@
 
 MacOS:
   install_dir: /opt/github/actions-runner
+  package_hash: b2c91416b3e4d579ae69fc2c381fc50dbda13f1b3fcc283187e2c75d1b173072
   script_suffix: sh
 
 Linux:
   install_dir: /opt/github/actions-runner
+  package_hash: ba46ba7ce3a4d7236b16fbe44419fb453bc08f866b24f04d549ec89f1722a29e
   script_suffix: sh
 
 Windows:
   install_dir: 'C:/github/actions-runner'
+  package_hash: 88d754da46f4053aec9007d172020c1b75ab2e2049c08aef759b643316580bbc
   script_suffix: cmd

--- a/pillar.example
+++ b/pillar.example
@@ -3,7 +3,7 @@ github-runner:
   # You can specify the GitHub Runner version, the default value is shown.
   # This should never need to be set unless you are hosting custom builds
   # of the GitHub runner. Don't do that.
-  version: '2.284.0'
+  version: '2.321.0'
   # One would only need change this if hosting custom builds
   base_url: 'https://github.com/actions/runner/releases/download'
   # POSIX systems represent the most common denominator for installation
@@ -19,5 +19,4 @@ github-runner:
   # You may want to tune the installation directory, which you can thusly
   install_dir: "/some/dir/I/really/want/to/use"
 
-  # If you wish to be extra careful you can specify the hash of the download
-  package_hash: "b4af45bc61ea3e531b9d124e9b8c21759267724cd72543a7aa943a389f1e6ec8"
+  package_hash: "ba46ba7ce3a4d7236b16fbe44419fb453bc08f866b24f04d549ec89f1722a29e"

--- a/pillar.example
+++ b/pillar.example
@@ -1,22 +1,24 @@
 ---
 github-runner:
-  # You can specify the GitHub Runner version, the default value is shown.
-  # This should never need to be set unless you are hosting custom builds
-  # of the GitHub runner. Don't do that.
-  version: '2.321.0'
-  # One would only need change this if hosting custom builds
-  base_url: 'https://github.com/actions/runner/releases/download'
-  # POSIX systems represent the most common denominator for installation
-  # platforms, so those defaults are used, Windows platforms will be
-  # detected when processing map.jinja, so no worries.
-  script_suffix: 'sh'
-  package_url: ''
-  package_suffix: 'tar.gz'
-  # The above settings show their defaults which will be over-ridden by
-  # the map.jinja so this need never be dealt with, unless you ignored
-  # my previous advice.
+  # Note that default values are commented out.
 
-  # You may want to tune the installation directory, which you can thusly
-  install_dir: "/some/dir/I/really/want/to/use"
+  # You can specify the GitHub Runner version. Note that the runner
+  # will automatically update itself as needed, so setting this is not
+  # required.
+  #version: '2.321.0'
 
-  package_hash: "ba46ba7ce3a4d7236b16fbe44419fb453bc08f866b24f04d549ec89f1722a29e"
+  # The SHA256 hash of the downloaded runner package.
+  #package_hash: "ba46ba7ce3a4d7236b16fbe44419fb453bc08f866b24f04d549ec89f1722a29e"
+
+  # One would only need change this if hosting custom builds.
+  #base_url: 'https://github.com/actions/runner/releases/download'
+
+  # If unset, the package download URL is automatically determined
+  # based on kernel, architecture and version.
+  #package_url: ''
+
+  # You can override the OS-specific installation path default.
+  # MacOS / Linux:
+  #install_dir: '/opt/github/actions-runner'
+  # Windows:
+  #install_dir: 'C:/github/actions-runner'

--- a/pillar.example
+++ b/pillar.example
@@ -1,7 +1,12 @@
 ---
 github-runner:
-  # Add your token from GitHub here.
+  ## Required
+
+  # Add your token from GitHub.
   repo_token: ''
+
+  # Add your GitHub account/org URL. eg. 'https://github.com/sitepoint'
+  repo_url: ''
 
   ## The following settings are optional. Defaults are commented out.
 

--- a/pillar.example
+++ b/pillar.example
@@ -1,5 +1,8 @@
 ---
 github-runner:
+  # Add your token from GitHub here.
+  repo_token: ''
+
   ## The following settings are optional. Defaults are commented out.
 
   # You can specify the GitHub Runner version. Note that the runner

--- a/pillar.example
+++ b/pillar.example
@@ -7,8 +7,14 @@ github-runner:
   # required.
   #version: '2.321.0'
 
-  # The SHA256 hash of the downloaded runner package.
-  #package_hash: "ba46ba7ce3a4d7236b16fbe44419fb453bc08f866b24f04d549ec89f1722a29e"
+  # The SHA256 hash of the downloaded runner package, which is OS-specific.
+  #
+  # MacOS:
+  #package_hash: 'b2c91416b3e4d579ae69fc2c381fc50dbda13f1b3fcc283187e2c75d1b173072'
+  # Linux:
+  #package_hash: 'ba46ba7ce3a4d7236b16fbe44419fb453bc08f866b24f04d549ec89f1722a29e'
+  # Windows:
+  #package_hash: '88d754da46f4053aec9007d172020c1b75ab2e2049c08aef759b643316580bbc'
 
   # One would only need change this if hosting custom builds.
   #base_url: 'https://github.com/actions/runner/releases/download'

--- a/pillar.example
+++ b/pillar.example
@@ -1,10 +1,10 @@
 ---
 github-runner:
-  # Note that default values are commented out.
+  ## The following settings are optional. Defaults are commented out.
 
   # You can specify the GitHub Runner version. Note that the runner
-  # will automatically update itself as needed, so setting this is not
-  # required.
+  # will automatically update itself as needed, so setting this is
+  # generally not required.
   #version: '2.321.0'
 
   # The SHA256 hash of the downloaded runner package, which is OS-specific.
@@ -23,7 +23,9 @@ github-runner:
   # based on kernel, architecture and version.
   #package_url: ''
 
-  # You can override the OS-specific installation path default.
+  # You can override the installation path default (which is
+  # OS-specific).
+  #
   # MacOS / Linux:
   #install_dir: '/opt/github/actions-runner'
   # Windows:

--- a/pillar.example
+++ b/pillar.example
@@ -13,6 +13,10 @@ github-runner:
   #  - arm64
   #  - Linux
 
+  # If you wish to use an existing runner group (other than
+  # "default"), it can be set here.
+  #runnergroup: rt-runnergroup
+
   # You can specify the GitHub Runner version. Note that the runner
   # will automatically update itself as needed, so setting this is
   # generally not required.

--- a/pillar.example
+++ b/pillar.example
@@ -5,6 +5,14 @@ github-runner:
 
   ## The following settings are optional. Defaults are commented out.
 
+  # Add any additional labels to the runner that you like. The values
+  # of the `cpuarch` and and `kernel` grains will always be added
+  # automatically.
+  # https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/using-labels-with-self-hosted-runners#programmatically-assign-labels
+  #labels:
+  #  - arm64
+  #  - Linux
+
   # You can specify the GitHub Runner version. Note that the runner
   # will automatically update itself as needed, so setting this is
   # generally not required.


### PR DESCRIPTION
This includes the following changes:
* Bumps the initial installation version from 2.284.0 to 2.321.0.
* Adds the possibility to deploy GitHub Runner on any operating system or architecture it supports (although I have only tested GNU/Linux on ARM64, YMMV).
* Fixes various bugs, such as syntax errors and undefined variable references that otherwise make it impossible to work.
* Creates a ghrunner user and group for unprivileged execution.
* Adds support for setting labels and/or a runnergroup.
* Improves the information in the pillar example, such as documenting how to set a token and eliminating the need for setting the script_suffix.

You could consider this a breaking change, but it was already not working to begin with.

One other thing to note is that the token appears to be one-time use, so if the plan is to run this state on a bunch of hosts, the user would need to find a way to generate tokens on-demand. However, a token is only used for the initial setup of a host and never looked at again. If just two runners were required, one could set the token in pillar, launch one, change the token in pillar, then launch the second. This isn't great, but it's an option.

Having said that, the way the token works isn't new to this PR; it's just that now we have _repo_token_ documented in the pillar.